### PR TITLE
feat: pagination for github repositories

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
     ldflags:
       - -X main.version={{ .Version }} -X main.commit={{ .Commit }} -X main.date={{ .CommitDate }}
 archives:
-    # e.g. releasegen_0.1.0_linux_aarch64.tar.gz, releasegen_0.1.0_linux_x86_64.tar.gz
+  # e.g. releasegen_0.1.0_linux_aarch64.tar.gz, releasegen_0.1.0_linux_x86_64.tar.gz
   - name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_
@@ -24,13 +24,13 @@ archives:
       {{- else if eq .Arch "arm64" }}aarch64
       {{- else }}{{ .Arch }}{{ end }}
     files:
-      - 'LICENSE*'
-      - 'README*'
+      - "LICENSE*"
+      - "README*"
 
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 release:
   prerelease: auto
   # Defaults to empty.
@@ -44,3 +44,4 @@ changelog:
   filters:
     exclude:
       - "^test:"
+version: 2

--- a/internal/github/team.go
+++ b/internal/github/team.go
@@ -42,15 +42,24 @@ func getTeamRepos(org OrgConfig, team string, orgRepos *[]repos.RepoDetails) ([]
 	ghRepos := []*Repository{}
 	ctx := context.Background()
 	opts := &gh.ListOptions{PerPage: githubPerPage}
+	allTeamRepos:= []*gh.Repository{}
 
 	// Lists the Github repositories that the 'ghTeam' has access to.
-	teamRepos, _, err := org.GithubClient().Teams.ListTeamReposBySlug(ctx, org.Org, team, opts)
-	if err != nil {
-		return nil, fmt.Errorf("error listing repositories for github org: %s", org.Org)
+	for {
+		teamRepos, resp, err := org.GithubClient().Teams.ListTeamReposBySlug(ctx, org.Org, team, opts)
+		if err != nil {
+			return nil, fmt.Errorf("error listing repositories for github org: %s", org.Org)
+		}
+		allTeamRepos = append(allTeamRepos, teamRepos...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
+	log.Printf("found %d repositories for github team: %s", len(allTeamRepos), team)
 
 	// Iterate over repositories, populating release info for each.
-	for _, tRepo := range teamRepos {
+	for _, tRepo := range allTeamRepos {
 		r := tRepo
 		// Check if the name of the repository is in the ignore list or private, or already processed.
 		if slices.Contains(org.IgnoredRepos, *r.Name) || *r.Private || repos.RepoInSlice(*orgRepos, *r.Name) {


### PR DESCRIPTION
There is no pagination in place, which leads to missing all repositories above the 100th.
This PR adds pagination to the listing of github repositories. It also adds a log showing the number of repositories found per team.

Also, this commit updates the goreleaser configuration to v2 to suppress warnings, and handles deprecation notices.